### PR TITLE
取引先、請求書、見積書の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,10 @@ gem 'jquery-rails'
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
-gem 'pry-rails', group: [:development, :test] 
+gem 'pry-rails', group: [:development, :test]
+gem 'wicked_pdf'
+gem 'wkhtmltopdf-binary'
+
 group :development, :test do
   gem 'sqlite3', "~> 1.3.6"
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
@@ -57,11 +60,9 @@ group :development do
   gem 'spring-watcher-listen', '~> 2.0.0'
 end
 
+group :production do
+  gem 'pg'
+end
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
-
-group :production do
-gem 'pg'
-end
-gem 'wicked_pdf'
-gem 'wkhtmltopdf-binary'

--- a/app/assets/stylesheets/invoices.scss
+++ b/app/assets/stylesheets/invoices.scss
@@ -17,7 +17,7 @@
   color: #191970;
   font-family: "游ゴシック Medium", "Yu Gothic Medium", "游ゴシック体", YuGothic,
     sans-serif;
-  font-size: 10.5pt;
+  font-size: 11pt;
   font-weight: normal;
   /* 背景色・背景画像を印刷する（Chromeのみで有効） */
   -webkit-print-color-adjust: exact;
@@ -42,10 +42,11 @@ ul {
   width: 210mm;
 
   /* 余白サイズ */
-  padding-top: 24mm;
-  padding-left: 21mm;
-  padding-right: 21mm;
-  padding-bottom: 21mm;
+  
+  padding-top: 15mm;
+  padding-left: 15mm;
+  padding-right: 15mm;
+  padding-bottom: 15mm;
 }
 
 /* プレビュー用のスタイル */
@@ -77,14 +78,14 @@ ul {
 /* 大枠の指定 */
 
 div.row_1 {
-  height: 0mm;
+  height: 5mm;
 }
 div.row_2 {
-  height: 0mm;
+  height: 5mm;
 }
 
 div.row_3 {
-  height: 65mm;
+  height: 60mm;
 }
 div.row_3 div.col_1 {
   width: 90mm;
@@ -100,7 +101,7 @@ div.row_4 {
   height: 18mm;
 }
 div.row_5 {
-  height: 70mm;
+  height: 75mm;
 }
 div.row_6 {
   height: 18mm;

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -1,6 +1,6 @@
 class InvoicesController < ApplicationController
   before_action :set_client
-  before_action :set_invoice, only: %i(show edit update destroy)
+  before_action :set_invoice, only: %i(index show edit update destroy)
 
   def index
     @invoices = @client.invoices
@@ -14,7 +14,7 @@ class InvoicesController < ApplicationController
                layout: 'pdf',
                encording: 'UTF-8',
                template: 'invoices/show',
-               orientation: 'Landscape'
+               orientation: 'Portrait'
       end
     end
   end
@@ -67,7 +67,7 @@ class InvoicesController < ApplicationController
   #共通処理なので、before_actionで呼び出している
   def set_invoice
     #特定データの取得
-    @invoice = Invoice.find(params[:id])
+    @invoice = Invoice.find(params[:client_id])
   end
 
   def set_client

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -1,6 +1,6 @@
 class InvoicesController < ApplicationController
   before_action :set_client
-  before_action :set_invoice, only: %i(index show edit update destroy)
+  before_action :set_invoice, only: %i(show edit update destroy)
 
   def index
     @invoices = @client.invoices
@@ -55,7 +55,7 @@ class InvoicesController < ApplicationController
     @invoice.destroy
     flash[:success] = "#{@invoice.due_date}のデータを削除しました。"
     #一覧ページへリダイレクト
-    redirect_to invoices_url
+    redirect_to client_invoices_path(@client)
   end
 
   private
@@ -67,7 +67,11 @@ class InvoicesController < ApplicationController
   #共通処理なので、before_actionで呼び出している
   def set_invoice
     #特定データの取得
-    @invoice = Invoice.find(params[:client_id])
+    # @invoice = Invoice.find(params[:id])
+    unless @invoice = @client.invoices.find_by(id: params[:id])
+      flash[:danger] = "権限がありません。"
+      redirect_to client_invoices_url @client
+    end
   end
 
   def set_client

--- a/app/views/clients/index.html.erb
+++ b/app/views/clients/index.html.erb
@@ -1,8 +1,8 @@
-<h1>顧客一覧</h1>
+<h1>取引先一覧</h1>
 <table class="table">
 <tr>
-  <td>顧客番号</td>
-  <td>顧客名</td>
+  <td>取引先番号</td>
+  <td>取引先名</td>
   <td>郵便番号</td>
   <td>住所</td>
   <td>担当者名</td>
@@ -10,6 +10,8 @@
   <td>詳細</td>
   <td>編集</td>
   <td>削除</td>
+  <td>請求書</td>
+  <td>見積書</td>
 </tr>
   <% @clients.each do |client| %>
 
@@ -23,6 +25,8 @@
       <td><%= link_to "詳細", client, class: "btn btn-success" %></td>
       <td><%= link_to "編集", edit_client_path(client), class: "btn btn-warning" %></td>
       <td><%= button_to "削除", client, method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-danger" %></td>
+      <td><%= link_to "請求書", client_invoices_path(client), class: "btn btn-info" %></td>
+      <td><%= link_to "見積書", client_quotations_path(client), class: "btn btn-secondary" %></td>
     </tr>
   <% end %>
 </table>

--- a/app/views/invoices/edit.html.erb
+++ b/app/views/invoices/edit.html.erb
@@ -5,7 +5,7 @@
 <div class="row">
   <div class="col-md-6 col-md-offset-3">
     <!-- @invoiceという変数をコントローラから受け取るとする。 -->
-    <%= form_for @invoice do |f| %>
+    <%= form_with(model: @invoice, url: client_invoice_path(@client, @invoice), local: true, method: :patch) do |f| %>
       <%= f.label :sales_staff, "営業担当者", class: "label-signup" %>
       <%= f.text_field :sales_staff, class: 'form-control' %>
 

--- a/app/views/invoices/index.html.erb
+++ b/app/views/invoices/index.html.erb
@@ -15,6 +15,7 @@
     <td>消費税</td>
     <td>合計</td>
     <td>詳細</td>
+    <td>出力</td>
     <td>編集</td>
     <td>削除</td>
     </tr>  
@@ -34,6 +35,7 @@
       <td><%= invoice.tax %></td>
       <td><%= invoice.total_fee %></td>
       <td><%= link_to '詳細', client_invoice_path(@client, invoice), class: "btn btn-success" %></td>
+      <td><%= link_to '出力', client_invoice_path(format: :pdf, id: @invoice.id), class: "btn btn-secondary" %></td>
       <td><%= link_to '編集', edit_client_invoice_path(@client, invoice), class: "btn btn-warning" %></td>
       <td><%= button_to '削除', client_invoice_path(@client, invoice), method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-danger" %></td>
     </tr>

--- a/app/views/invoices/index.html.erb
+++ b/app/views/invoices/index.html.erb
@@ -35,7 +35,7 @@
       <td><%= invoice.tax %></td>
       <td><%= invoice.total_fee %></td>
       <td><%= link_to '詳細', client_invoice_path(@client, invoice), class: "btn btn-success" %></td>
-      <td><%= link_to '出力', client_invoice_path(format: :pdf, id: @invoice.id), class: "btn btn-secondary" %></td>
+      <td><%= link_to '出力', client_invoice_path(format: :pdf, id: invoice.id), class: "btn btn-secondary" %></td>
       <td><%= link_to '編集', edit_client_invoice_path(@client, invoice), class: "btn btn-warning" %></td>
       <td><%= button_to '削除', client_invoice_path(@client, invoice), method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-danger" %></td>
     </tr>

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <style type="text/css">
+      table { page-break-inside:auto }
+    tr { page-break-inside:avoid; page-break-after:auto } 
+    </style>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <link rel="stylesheet" href="sheet.css">
+    <title>請求書</title>
+</head>
+
+<body>
+    <section class="sheet">
+        <div class="row_2">
+            <h5 class="text-right">請求書番号    [100]</h5>
+            <h5 class="text-right">日付  2021年8月31日</h5>
+        </div>
+        <div class="row_1">
+          <ul>
+            <h3 class="text-center">請  求  書</h3>
+          </ul>
+        </div>
+        <div class="row_3">
+            <div class="col_1">
+                <ul>
+                    <li>
+                        <h6 class="customer_name">(株)エス・マーケティング・デザイン・ジャパン 御中</h6>
+                    </li>
+                    <li class="text-left">〒150-0001</li>
+                    <li class="text-left">東京都渋谷区神宮前6-25-8</li>
+                    <li class="text-left">神宮前コーポラス 1408号</li>
+                    <li class="text-left">TEL 03-6419-7730</li>
+                </ul>
+            </div>
+            <div class="col_2">
+                <ul >
+                    <li>
+                        <h4 class="text-left">株式会社Trust Material</h4>
+                    </li>
+                    <li class="text-left">〒703-8243</li>
+                    <li class="text-left">岡山県岡山市中区清水502-202</li>
+                    <li class="text-left">代表取締役 木野 誠也</li>
+                    <li class="text-left">TEL 080-6133-6111</li>
+                </ul>
+            </div>
+            <div class="clear-element"></div>
+        </div>
+
+        <div class="row_4">
+            <table class="detail">
+                <thead>
+                    <tr>
+                        <th class="contact_person">営業担当者</th>
+                        <th class="product_name">品名</th>
+                        <th class="payment_terms">支払条件</th>
+                        <th class="fixed_date">期日</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr class="dataline">
+                        <td class="text-center">丸川 伸</td>
+                        <td class="text-center">イベント委託費</td>
+                        <td class="text-center">振り込み</td>
+                        <td class="text-center">2021.9.30</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <div class="row_5">
+            <table class="detail">
+                <thead>
+                    <tr>
+                        <th class="item">内容</th>
+                        <th class="amount">数量</th>
+                        <th class="unit_price">単価</th>
+                        <th class="subtotal">金額</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr class="dataline">
+                        <td class="text-left">コスモカード 人件費</td>
+                        <td></td>
+                        <td></td>
+                        <td>¥282,656</td>
+                    </tr>
+                    <tr class="dataline">
+                      <td class="text-left">コスモカード 獲得インセンティブ</td>
+                      <td></td>
+                      <td></td>
+                      <td>¥5,500</td>
+                  </tr>
+                    <tr class="dataline">
+                      <td class="text-left">コスモカードスタッフ 交通費</td>
+                      <td></td>
+                      <td></td>
+                      <td>¥38,790</td>
+                  </tr>
+                    <tr class="dataline">
+                        <td> </td>
+                        <td> </td>
+                        <td> </td>
+                        <td> </td>
+                    </tr>
+                    <tr class="dataline">
+                      <td class="text-left">通信事業 人件費</td>
+                      <td></td>
+                      <td></td>
+                      <td>¥1,972,642</td>
+                  </tr>
+                    <tr class="dataline">
+                      <td class="text-left">通信事業 交通費 ※備品代込</td>
+                      <td></td>
+                      <td></td>
+                      <td>¥366,880</td>
+                  </tr>
+                    <tr class="dataline">
+                        <td> </td>
+                        <td> </td>
+                        <td> </td>
+                        <td> </td>
+                    </tr>
+                    <tr class="dataline">
+                      <td class="text-left">通信事業（山陰ライン） 人件費</td>
+                      <td></td>
+                      <td></td>
+                      <td>¥1,437,540</td>
+                  </tr>
+                    <tr class="dataline">
+                      <td class="text-left">通信事業（山陰ライン） 交通費 ※備品代込</td>
+                      <td></td>
+                      <td></td>
+                      <td>¥200,690</td>
+                  </tr>
+                    <tr class="dataline">
+                        <td> </td>
+                        <td> </td>
+                        <td> </td>
+                        <td> </td>
+                    </tr>
+                    <tr>
+                        <td class="space" rowspan="3" colspan="2"> </td>
+                        <th> 小計 </th>
+                        <td> ¥4,304,698 </td>
+                    </tr>
+                    <tr>
+                        <th> 消費税 </th>
+                        <td> ¥369,834 </td>
+                    </tr>
+                    <tr>
+                        <th> 合計 </th>
+                        <td> ¥4,674,532 </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <ul>
+          <li class="text-left">中国銀行 倉敷北支店</li>
+          <li class="text-left">普通 1397719</li>
+          <li class="text-left">株式会社Trust Material</li>
+          <li class="text-left">代表取締役 木野 誠也</li>
+          <li class="text-left">いつもご利用ありがとうございます。</li>
+        </ul>
+    </section>
+</body>
+
+</html>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -3,9 +3,18 @@
     <%= link_to "TrustMterial", root_path, id: "logo" %>
     <nav>
       <ul class="nav navbar-nav navbar-right">
-        <li><%= link_to "Top",   root_path %></li>
-        <li><%= link_to "ログイン", user_session_path %></li>
-        <li><%= link_to "ログアウト", logout_path %></li>
+        <% if user_signed_in? %>
+          <% if current_user.id == 1 %>
+            <li><%= link_to "Top",   root_path %></li>
+            <li><%= link_to "ログイン", user_session_path %></li>
+            <li><%= link_to "ログアウト", logout_path %></li>
+            <li><%= link_to "取引先", clients_path %></li>
+          <% else %>
+            <li><%= link_to "Top",   root_path %></li>
+            <li><%= link_to "ログイン", user_session_path %></li>
+            <li><%= link_to "ログアウト", logout_path %></li>
+          <% end %>
+        <% end %>
       </ul>
     </nav>
   </div>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -2,6 +2,7 @@
 <div class="center jumbotron">
   <h1>勤怠管理システム</h1>
   <p>このアプリケーションでは、登録されたユーザーの勤怠情報を閲覧・登録・編集することができます。</p>
- <%= link_to "新規作成", new_user_registration_path, class: "btn btn-lg btn-primary" %>
+ <%= link_to "新規作成", new_user_registration_path, class: "btn btn-lg btn-primary" %><br>
+ <%= link_to "ログイン", user_session_path, class: "btn btn-lg btn-primary" %>
 </div>
 </div>


### PR DESCRIPTION
##概要
このブランチで何を行ったのか？
・取引先は管理者のみが編集・閲覧できるようにするため、管理者でログインした時にheaderに取引先ボタンが表示されるように実装。
・取引先ボタン押下で取引先一覧が表示される。取引先追加ボタンを実装。追加ボタン押下で取引先登録場面へ遷移する。取引先一覧の項目に詳細、編集、削除、請求書、見積書ボタンを実装。請求書ボタン押下で請求書一覧へ、見積書ボタン押下で見積書一覧へ遷移する。
・見積書一覧に見積書追加ボタンを実装。追加ボタン押下で見積書登録場面へ遷移する。編集、削除の機能は未実装。
・請求書一覧に請求書追加ボタンを実装。追加ボタン押下で請求書登録場面へ遷移する。請求書一覧の項目に詳細、編集、出力、削除ボタンを実装。出力ボタン押下で請求書がpdfファイルで出力できる。請求書詳細画面に直接入力し保存できる機能は未実装。
##動作確認、イメージ
どのような動作確認を行ったのか？結果はどうか？
画像などありましたら画像の添付をお願いします。
・動画を添付いたします。取引先→◯、請求書→◯、見積書→◯
##検証項目
・バリデーション 取引先：顧客番号、取引先名が必須、請求書：なし、見積書：なし