### PR TITLE
取引先登録が空登録できないように修正

### DIFF
--- a/app/controllers/clients_controller.rb
+++ b/app/controllers/clients_controller.rb
@@ -15,8 +15,11 @@ before_action :set_client, only: [:show, :edit, :update, :destroy]
 
   def create
     @client = Client.new(client_params)
-    @client.save
-    redirect_to client_path(@client)
+    if @client.save
+      redirect_to client_path(@client)
+    else
+      render ("clients/new")
+    end
   end
 
   #edit->編集ページの表示

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -3,5 +3,5 @@ class Client < ApplicationRecord
   has_many :quotations, dependent: :destroy
   has_many :tusin_quotations, dependent: :destroy
   has_many :sanin_quotations, dependent: :destroy
-  validates :client_name,  presence: true, length: { maximum: 50 }
+  validates :client_name,  {presence: true, length: { maximum: 50 }}
 end


### PR DESCRIPTION
取引先登録を空でしようとする際のエラーを条件分岐とrenderすることで解消いたしました。動画を添付いたしますのでご確認ください。
