### PR TITLE
4/17 0703 平野css再修正完了

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -316,6 +316,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-18
+  x86_64-darwin-20
 
 DEPENDENCIES
   activerecord
@@ -366,4 +367,4 @@ RUBY VERSION
    ruby 2.7.4p191
 
 BUNDLED WITH
-   2.2.16
+   2.3.8

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -601,10 +601,17 @@ textarea {
   width: 220px;
 }
 
+/*index_admin_1.html*/
 .carfare_width_1{
   width: 250px;
 }
 
-.carfare_width_2{
-  width: 100px;
+/*index_admin_1.html*/
+.carfare_width_A{
+  width: 200px;
+}
+
+/*index_admin_1.html*/
+.search_width_1{
+  width: 200px;
 }

--- a/app/views/carfares/index_admin_1.html.erb
+++ b/app/views/carfares/index_admin_1.html.erb
@@ -71,7 +71,7 @@
         <th>移動距離</th>
         <th>高速料金</th>
         <th>伝票画像</th>
-        <th>承認申請</th>
+        <th class="carfare_width_A">承認申請</th>
         <th class="carfare_width_1"></th>
       </tr>
     </thead>

--- a/app/views/carfares/search_1.html.erb
+++ b/app/views/carfares/search_1.html.erb
@@ -1,4 +1,4 @@
-<div class="carfare-t">
+app/views/carfares/search_admin.html.erb<div class="carfare-t">
 <h1 style="color: #800080">＜＜検索結果＞＞</h1>
 <h1>
     交通費管理画面（自家用車）
@@ -68,7 +68,7 @@
         <th>高速料金</th>
         <th>伝票画像</th>
         <th>申請状況</th>
-        <th colspan="2" ></th>
+        <th colspan="2" class="carfare_width"></th>
       </tr>
     </thead>
 
@@ -152,6 +152,7 @@
               <% end %>
             <% end %>
           <% end %>
+          <td><%= button_to '削除',destroy_1_user_carfare_path(id: result), method: :delete, class: "btn btn-sm btn-danger" %></td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/carfares/search_admin.html.erb
+++ b/app/views/carfares/search_admin.html.erb
@@ -85,7 +85,7 @@
           <th>高速料金</th>
           <th>伝票画像</th>
           <th>承認申請（承認/否認）</th>
-          <th></th>
+          <th class="carfare_width"></th>
         </tr>
       </thead>
       <tbody  class="table table-bordered table-condensed">

--- a/app/views/carfares/search_admin_1.html.erb
+++ b/app/views/carfares/search_admin_1.html.erb
@@ -85,8 +85,8 @@
         <th>移動距離</th>
         <th>高速料金</th>
         <th>伝票画像</th>
-        <th>承認申請</th>
-        <th></th>
+        <th class="search_width_1">承認申請</th>
+        <th class="search_width_1"></th>
       </tr>
     </thead>
     <tbody  class="table table-bordered table-condensed">


### PR DESCRIPTION
お疲れ様です。
平野担当箇所のcssの崩れを一旦修正致しました。
宜しくお願いいたします。
＜修正箇所＞
（修正前）以下のような隙間が検索結果のページでも発生しておりましたので修正。
<img width="1413" alt="スクリーンショット 2022-04-11 0 10 23" src="https://user-images.githubusercontent.com/57516674/163692794-d2fe1a8f-1c10-4c37-a45a-991beed189ad.png">




（修正後）
<img width="1433" alt="スクリーンショット 2022-04-17 7 09 49" src="https://user-images.githubusercontent.com/57516674/163692831-87b8a474-765a-4de0-8919-c70a1498d167.png">

宜しくお願い致します。



